### PR TITLE
Fixed bad send_failure() call

### DIFF
--- a/Chapter07/05_static_middleware/app/handlers/pages.js
+++ b/Chapter07/05_static_middleware/app/handlers/pages.js
@@ -14,7 +14,7 @@ exports.generate = function (req, res) {
         'basic.html',
         function (err, contents) {
             if (err) {
-                send_failure(res, err);
+                helpers.send_failure(res, 500, err);
                 return;
             }
 


### PR DESCRIPTION
`send_failure` should be called from `helpers` module using 3 arguments.